### PR TITLE
Updating exports for pinterest

### DIFF
--- a/lib/integrations.js
+++ b/lib/integrations.js
@@ -40,7 +40,7 @@ module.exports = {
     'visual-website-optimizer': require('@astronomerio/analytics.js-integration-visual-website-optimizer'),
     'woopra': require('@astronomerio/analytics.js-integration-woopra'),
     'heap': require('@astronomerio/analytics.js-integration-heap'),
-    'pinterest-conversions': require('@astronomerio/analytics.js-integration-pinterest-conversions'),
+    'pinterest-tag': require('@astronomerio/analytics.js-integration-pinterest-conversions'),
     'resonate': require('@astronomerio/analytics.js-integration-resonate'),
     'pebble-post': require('@astronomerio/analytics.js-integration-pebble-post'),
     'hotjar': require('@astronomerio/analytics.js-integration-hotjar'),


### PR DESCRIPTION
Need to change pinterest-conversions to pinterest-tag for consistent reference to documents in mongodb.